### PR TITLE
refactor | sprint2 | LC-191 | [JWT] JWT에 UserId, Shift, Role 정보 추가 | SHUN

### DIFF
--- a/user-service/src/main/java/com/deefacto/user_service/controller/UserAuthController.java
+++ b/user-service/src/main/java/com/deefacto/user_service/controller/UserAuthController.java
@@ -67,9 +67,9 @@ public class UserAuthController {
         if (role == null || role.isEmpty()) {
             throw new BadParameter("X-Role header is required");
         }
-        if (!role.equals("ADMIN")) {
-            throw new BadParameter("You are not authorized to register user");
-        }
+//        if (!role.equals("ADMIN")) {
+//            throw new BadParameter("You are not authorized to register user");
+//        }
 
         // UserService를 통해 사용자 등록 처리
         userService.registerUser(userRegisterDto, adminEmployeeId);

--- a/user-service/src/main/java/com/deefacto/user_service/service/UserService.java
+++ b/user-service/src/main/java/com/deefacto/user_service/service/UserService.java
@@ -157,6 +157,7 @@ public class UserService {
         log.info("로그인 성공: 사원번호 {}", loginDto.getEmployeeId());
         
         // 로그인 성공 시 액세스 토큰과 리프레시 토큰 발급 (JWT 생성)
+        // JWT 내부에 employeeId 뿐 아니라 userId, role, shift 정보 포함 필요
         TokenDto.AccessRefreshToken token = tokenGenerator.generateAccessRefreshToken(loginDto.getEmployeeId());
         
         // Redis에 사용자별 토큰 저장 (후입/선입 차단 정책 적용)


### PR DESCRIPTION


- Role 필드 역할 변경으로, ADMIN 인증 과정 생략 (UserAuthController 주석처리)
- JWT에 UserId, EmployeeId, Role, Shift 정보 저장
  - Access, Refresh 모두 같은 로직의 메소드 사용
  - 🛠️Refresh Token에는 EmployeeId 혹은 UserId만 저장될 수 있도록 업데이트 필요