### PR TITLE
refactor | sprint3 | LC-114, LC-115, LC-109, LC-442, LC-111 | User Role(ROOT, ADMIN, USER), Scope(a,b,c) 구분 | SHUN

### DIFF
--- a/user-service/src/main/java/com/deefacto/user_service/domain/Entitiy/User.java
+++ b/user-service/src/main/java/com/deefacto/user_service/domain/Entitiy/User.java
@@ -57,7 +57,11 @@ public class User {
 
     @Column(name = "role", nullable = false)
     @Getter @Setter
-    private String role; // 권한
+    private String role; // 권한 (ROOT, ADMIN, USER)
+
+    @Column(name = "scope", nullable = false)
+    @Getter @Setter
+    private String scope; // 구역 범위 (a,b,c)
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false)
@@ -75,7 +79,7 @@ public class User {
 
     @Column(name = "shift")
     @Getter @Setter
-    private String shift; // 근무 시간
+    private String shift; // 근무 시간 (DAY, NIGHT)
 
     @Column(name = "created_pr", nullable = false)
     @Getter @Setter

--- a/user-service/src/main/java/com/deefacto/user_service/domain/dto/UserCacheDto.java
+++ b/user-service/src/main/java/com/deefacto/user_service/domain/dto/UserCacheDto.java
@@ -17,6 +17,8 @@ public class UserCacheDto {
     private String name;
     // 권한
     private String role;
+    // 구역 범위
+    private String scope;
     // 근무시간
     private String shift;
 }

--- a/user-service/src/main/java/com/deefacto/user_service/domain/dto/UserInfoResponseDto.java
+++ b/user-service/src/main/java/com/deefacto/user_service/domain/dto/UserInfoResponseDto.java
@@ -51,6 +51,11 @@ public class UserInfoResponseDto {
      * 권한
      */
     private String role;
+
+    /**
+     * 구역 범위
+     */
+    private String scope;
     
     /**
      * 생성일
@@ -101,6 +106,7 @@ public class UserInfoResponseDto {
             .department(user.getDepartment())
             .position(user.getPosition())
             .role(user.getRole())
+                .scope(user.getScope())
             .createdAt(user.getCreatedAt())
             .updatedAt(user.getUpdatedAt())
             .shift(user.getShift())

--- a/user-service/src/main/java/com/deefacto/user_service/domain/dto/UserRegisterDto.java
+++ b/user-service/src/main/java/com/deefacto/user_service/domain/dto/UserRegisterDto.java
@@ -49,6 +49,9 @@ public class UserRegisterDto {
 
     private String role;
 
+    @NotBlank(message = "scope is compulsory")
+    private String scope;
+
     private String shift;
 
     private LocalDateTime createdAt;
@@ -72,6 +75,7 @@ public class UserRegisterDto {
         user.setDepartment(this.department);
         user.setPosition(this.position);
         user.setRole(this.role);
+        user.setScope(this.scope);
         user.setShift(this.shift);
         user.setCreatedAt(LocalDateTime.now());
         user.setUpdatedAt(LocalDateTime.now());

--- a/user-service/src/main/java/com/deefacto/user_service/domain/repository/UserRepository.java
+++ b/user-service/src/main/java/com/deefacto/user_service/domain/repository/UserRepository.java
@@ -34,13 +34,13 @@ public interface UserRepository extends JpaRepository<User, Long> {
     );
 
     @Query("SELECT u.id FROM User u " +
-            "WHERE (u.role LIKE CONCAT(:role, ',%') " +
-            "OR u.role LIKE CONCAT('%,', :role, ',%') " +
-            "OR u.role LIKE CONCAT('%,', :role) " +
-            "OR u.role = :role) " +
+            "WHERE (u.scope LIKE CONCAT(:scope, ',%') " +
+            "OR u.scope LIKE CONCAT('%,', :scope, ',%') " +
+            "OR u.scope LIKE CONCAT('%,', :scope) " +
+            "OR u.scope = :scope) " +
             "AND u.shift = :shift " +
             "AND u.isActive = true")
-    List<Long> findUserIdsByRoleAndShift(@Param("role") String role, @Param("shift") String shift);
+    List<Long> findUserIdsByScopeAndShift(@Param("scope") String scope, @Param("shift") String shift);
 
 
 }

--- a/user-service/src/main/java/com/deefacto/user_service/remote/dto/UserMessage.java
+++ b/user-service/src/main/java/com/deefacto/user_service/remote/dto/UserMessage.java
@@ -11,7 +11,7 @@ public class UserMessage {
     public static class UserRequestMessage {
         private Long notificationId;
         private String zoneId;
-        private String shift; // 예: "A", "B"
+        private String shift; // 예: "DAY", "NIGHT"
     }
 
     // 사용자 조회 응답 메시지

--- a/user-service/src/main/java/com/deefacto/user_service/remote/service/UserRequestConsumer.java
+++ b/user-service/src/main/java/com/deefacto/user_service/remote/service/UserRequestConsumer.java
@@ -37,7 +37,7 @@ public class UserRequestConsumer {
     }
 
     private List<Long> queryUsersByZoneAndShift(String zoneId, String shift) {
-        return userRepository.findUserIdsByRoleAndShift(zoneId, shift);
+        return userRepository.findUserIdsByScopeAndShift(zoneId, shift);
     }
 }
 

--- a/user-service/src/main/java/com/deefacto/user_service/secret/jwt/TokenGenerator.java
+++ b/user-service/src/main/java/com/deefacto/user_service/secret/jwt/TokenGenerator.java
@@ -5,7 +5,7 @@ import java.util.Date;
 
 import com.deefacto.user_service.domain.Entitiy.User;
 import com.deefacto.user_service.domain.repository.UserRepository;
-import com.deefacto.user_service.remote.service.UserCacheService;
+import com.deefacto.user_service.service.UserCacheService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +34,8 @@ import io.jsonwebtoken.security.Keys;
 @Component
 @RequiredArgsConstructor
 public class TokenGenerator {
+
+    private final long USER_CACHE_TTL_MIN = 20;
 
     // JWT 설정 정보 (시크릿 키, 만료 시간 등)
     private final JwtConfig jwtConfig;
@@ -106,9 +108,7 @@ public class TokenGenerator {
             .issuer("deefacto")                    // 토큰 발급자
             .setSubject(employeeId)                // 토큰 주체 (사용자 ID)
             .claim("EmployeeId", employeeId)       // 사용자 사원번호 클레임
-//                .claim("UserId", user.getId())
-//                .claim("Shift", user.getShift())
-//                .claim("Role", user.getRole())
+                .claim("UserId", user.getId())
             .claim("type", tokenType)              // 토큰 타입 클레임 (access/refresh)
             .issuedAt(new Date())                  // 토큰 발급 시간
             .expiration(new Date(System.currentTimeMillis() + expriresIn * 1000L))  // 토큰 만료 시간
@@ -226,8 +226,9 @@ public class TokenGenerator {
         // 리프레시 토큰에서 사용자 ID 추출
         String employeeId = getEmployeeIdFromToken(refreshToken);
 
-        // 리프레시 토큰 연장 시 user 정보도 연장
-        userCacheService.refreshUserCacheTTL(employeeId,60);
+        User user = userRepository.findByEmployeeId(employeeId);
+
+        userCacheService.saveOrUpdateUser(user, USER_CACHE_TTL_MIN);
 
         // 새로운 액세스 토큰 생성
         return generateAccessToken(employeeId);

--- a/user-service/src/main/java/com/deefacto/user_service/service/UserCacheService.java
+++ b/user-service/src/main/java/com/deefacto/user_service/service/UserCacheService.java
@@ -1,4 +1,4 @@
-package com.deefacto.user_service.remote.service;
+package com.deefacto.user_service.service;
 
 import com.deefacto.user_service.domain.Entitiy.User;
 import com.deefacto.user_service.domain.dto.UserCacheDto;
@@ -17,13 +17,14 @@ public class UserCacheService {
     private final ObjectMapper objectMapper;
 
     // 필요한 유저 정보만 담아 redis에 저장
-    public void saveUser(User user, long ttlMinutes) {
+    public void saveOrUpdateUser(User user, long ttlMinutes) {
         try {
             UserCacheDto cacheDto = new UserCacheDto(
                     user.getId(),
                     user.getEmployeeId(),
                     user.getName(),
                     user.getRole(),
+                    user.getScope(),
                     user.getShift()
             );
 
@@ -32,15 +33,6 @@ public class UserCacheService {
             redisTemplate.opsForValue().set(key, value, ttlMinutes, TimeUnit.MINUTES);
         } catch (JsonProcessingException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    // refreshToken 발급 시 TTL 연장
-    public void refreshUserCacheTTL(String employeeId, long ttlMinutes) {
-        String key = "user:" + employeeId;
-        Boolean exists = redisTemplate.hasKey(key);
-        if(Boolean.TRUE.equals(exists)) {
-            redisTemplate.expire(key, ttlMinutes, TimeUnit.MINUTES);
         }
     }
 }


### PR DESCRIPTION
- Role, Scope 구분
  - 권한: Role = {ROOT, ADMIN, USER}
  - 구역 범위: Scope = {a,b,c}

- JWT userId, employeeId만 포함하도록 수정
  - role, scope, shift,name 정보는 Redis에 저장하여, 다른 마이크로서비스에서도 사용할 수 있도록 하였음.
  - 사용자 정보 변경 시, Redis에도 바로 적용 (즉각 업데이트)

- 비밀번호 수정 시, 새 비밀번호 유효성 검사 로직 추가 (4~20)
- 본인만 비밀번호 수정 가능 (기존: ROOT도 가능)
- 사용자 삭제는 ROOT 계정만 가능하되, 자기자신 삭제 불가능
  - ROOT 계정 삭제 방지